### PR TITLE
Implementation of a non-command.

### DIFF
--- a/console.py
+++ b/console.py
@@ -93,7 +93,7 @@ class HBNBCommand(cmd.Cmd):
                         key = "{}.{}".\
                             format(args[0], args[1])
                         if key == obj_key:
-                            del(all_obj[key])
+                            del (all_obj[key])
                             storage.save()
                             return
                     print("** no instance found **")
@@ -156,6 +156,12 @@ class HBNBCommand(cmd.Cmd):
                                     print("** no instance found **")
         else:
             print("** class name missing **")
+
+    def onecmd(self, line):
+        arg = line.split('.')
+        if arg[0] in self.class_list and arg[1] == "all()":
+            line = "all " + arg[0]
+        return cmd.Cmd.onecmd(self, line)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit creates a feature similar to the all command. Unlike the 'all' command it is a non-command consisting of a class_name joined to notation of an all function, by a dot. The command line argument is paired and stripped of the dot in the middle while checks for prefixing word ensues to establish it as a valid class. This is followed by a call to the all command, and the class_name passed as the argument to the command, generating all subsisting instances of the class from files storage to the screen.